### PR TITLE
Removing cases of UnicodeDecodeError from psaux.py

### DIFF
--- a/volatility/framework/plugins/mac/psaux.py
+++ b/volatility/framework/plugins/mac/psaux.py
@@ -80,8 +80,11 @@ class Psaux(plugins.PluginInterface):
                     args.append(arg)
 
                 argc = argc - 1
-
-            args_str = " ".join([s.decode("utf-8") for s in args])
+                
+            try:
+                args_str = " ".join([s.decode("utf-8") for s in args])
+            except:
+                pass
 
             yield (0, (task.p_pid, task_name, task.p_argc, args_str))
 


### PR DESCRIPTION
Small patch ::: Generation of UnicodeDecodeError in the processing of file by psaux.exe stops execution of next PID's in the cycle. This patch would enable psaux.py to skip error generating PID and display result of next PID's, thus ensuring complete output result.